### PR TITLE
feat: support case-insensitive matching on the signoffs

### DIFF
--- a/__tests__/pr-body-validation.service.test.ts
+++ b/__tests__/pr-body-validation.service.test.ts
@@ -40,6 +40,14 @@ This changes X, Y, Z
 - [x] **Author(s):** I have reviewed the Code Safety Guidelines
 `;
 
+const prBodyCompleteUppercaseX: string = `# Summary
+**Describe the changes:**
+This changes X, Y, Z
+
+# Sign off
+- [X] **Author(s):** I have reviewed the Code Safety Guidelines
+`;
+
 var testCases = [
   {
     title: 'A PR Description that is NULL should fail and return: ',
@@ -77,6 +85,13 @@ var testCases = [
       'A PR Description without placeholders that is signed off should pass and return: ',
     expectedMessagePrefix: 'Nice work',
     body: prBodyComplete,
+    isPrBodyCompleteExpected: true,
+  },
+  {
+    title:
+      'A PR Description without placeholders that is signed off with a capital X should pass and return: ',
+    expectedMessagePrefix: 'Nice work',
+    body: prBodyCompleteUppercaseX,
     isPrBodyCompleteExpected: true,
   },
 ];

--- a/src/pr-body-validation.service.ts
+++ b/src/pr-body-validation.service.ts
@@ -51,7 +51,7 @@ export class PrBodyValidationService {
 
       const isFinalChecklistComplete = this.completedFinalChecklist.every(
         function (item) {
-          return prBody.includes(item);
+          return prBody.toLowerCase().includes(item.toLowerCase());
         },
       );
 


### PR DESCRIPTION
# 💬 Summary
using this action for some time now, the biggest adoption issue has been people unknowingly using uppercase 'X', instead of lowercase 'x', and not knowing why their PR isn't working.

**i can't really sign off on these checklists below because i don't have access to the links** (leaving in draft until i can receive some feedback)

# 🏁 Sign off
- [x] **Author(s):** I have reviewed the [Code Safety Guidelines](https://tinyurl.com/y79wkekq), I am **99% sure** these changes are **safe to merge** and have explained the reasons why

**If you are unsure about any of the above information, speak to department/tech lead to discuss what other options are available to increase confidence**